### PR TITLE
Feature/tarot card reading

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,8 @@
       "dependencies": {
         "discord.js": "^14.12.1",
         "dotenv": "^16.3.1",
+        "fs": "^0.0.1-security",
+        "path": "^0.12.7",
         "prettier": "^3.2.5",
         "react": "^18.2.0"
       },
@@ -224,6 +226,16 @@
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
       "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
     },
+    "node_modules/fs": {
+      "version": "0.0.1-security",
+      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
+      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
+    },
+    "node_modules/inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha512-x00IRNXNy63jwGkJmzPigoySHbaqpNuzKbBOmzK+g2OdZpQ9w+sxCN+VSB3ja7IAge2OP2qpfxTjeNcyjmW1uw=="
+    },
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
@@ -255,6 +267,15 @@
       "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.10.0.tgz",
       "integrity": "sha512-/k20Lg2q8LE5xiaaSkMXk4sfvI+9EGEykFS4b0CHHGWqDYU0bGUFSwchNOMA56D7TCs9GwVTkqe9als1/ns8UQ=="
     },
+    "node_modules/path": {
+      "version": "0.12.7",
+      "resolved": "https://registry.npmjs.org/path/-/path-0.12.7.tgz",
+      "integrity": "sha512-aXXC6s+1w7otVF9UletFkFcDsJeO7lSZBPUQhtb5O0xJe8LtYhj/GxldoL09bBj9+ZmE2hNoHqQSFMN5fikh4Q==",
+      "dependencies": {
+        "process": "^0.11.1",
+        "util": "^0.10.3"
+      }
+    },
     "node_modules/prettier": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.2.5.tgz",
@@ -267,6 +288,14 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
+      }
+    },
+    "node_modules/process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+      "engines": {
+        "node": ">= 0.6.0"
       }
     },
     "node_modules/react": {
@@ -305,6 +334,14 @@
       "version": "5.26.5",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA=="
+    },
+    "node_modules/util": {
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
+      "dependencies": {
+        "inherits": "2.0.3"
+      }
     },
     "node_modules/ws": {
       "version": "8.14.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
   "dependencies": {
     "discord.js": "^14.12.1",
     "dotenv": "^16.3.1",
+    "fs": "^0.0.1-security",
+    "path": "^0.12.7",
     "prettier": "^3.2.5",
     "react": "^18.2.0"
   },

--- a/src/discord/EventHandlers.js
+++ b/src/discord/EventHandlers.js
@@ -20,7 +20,7 @@ discordClient.on('messageCreate', async (message) => {
       const result = rollDice(dice);
       result === ''
         ? message.reply('Number of dice/sides must be between 1 and 20.')
-        : message.reply('You rolled ' + dice + '! ' + '\n' + result);
+        : message.reply('Rolling ' + dice + '... ' + '\n' + result);
     }
   }
 });

--- a/src/discord/EventHandlers.js
+++ b/src/discord/EventHandlers.js
@@ -2,6 +2,7 @@
 const { discordClient } = require('./ClientConfig');
 const { scramble } = require('../util/MessageScrambler');
 const { rollDice } = require('../dnd/dice/DiceRoller');
+const { tarotReading } = require('../dnd/tarot/TarotReader');
 
 var diceRegex = /(\d+)d(\d+)/;
 
@@ -21,6 +22,10 @@ discordClient.on('messageCreate', async (message) => {
       result === ''
         ? message.reply('Number of dice/sides must be between 1 and 20.')
         : message.reply('Rolling ' + dice + '... ' + '\n' + result);
+    }
+
+    if (userMsg.includes('tarot please')) {
+      message.reply(tarotReading());
     }
   }
 });

--- a/src/discord/EventHandlers.js
+++ b/src/discord/EventHandlers.js
@@ -18,8 +18,8 @@ discordClient.on('messageCreate', async (message) => {
     const userMsg = message?.content?.toLowerCase();
     if (userMsg.includes('dungeon help')) {
       message.reply(
-        `Need to roll dice? Just type \'roll\' followed by the number of dice and number of sides separated by the letter \'d\'. Just like this: \'Roll 2d8\'
-        \nHow about a tarot reading? Just say \'tarot please\'`
+        `1) Need to roll dice? Just type \'roll\' followed by the number of dice and number of sides separated by the letter \'d\'. Just like this: \'Roll 2d8\'
+        \n2) How about a tarot reading? Just say \'tarot please\'`
       );
     }
     if (userMsg.includes('roll') && userMsg.match(diceRegex)) {

--- a/src/discord/EventHandlers.js
+++ b/src/discord/EventHandlers.js
@@ -16,12 +16,18 @@ discordClient.on('messageCreate', async (message) => {
     (message.author.id != '1229569899853123584' || message.author.displayName != 'dungeon-bot')
   ) {
     const userMsg = message?.content?.toLowerCase();
+    if (userMsg.includes('dungeon help')) {
+      message.reply(
+        `Need to roll dice? Just type \'roll\' followed by the number of dice and number of sides separated by the letter \'d\'. Just like this: \'Roll 2d8\'
+        \nHow about a tarot reading? Just say \'tarot please\'`
+      );
+    }
     if (userMsg.includes('roll') && userMsg.match(diceRegex)) {
       const dice = userMsg.match(diceRegex)[0];
       const result = rollDice(dice);
       result === ''
-        ? message.reply('Number of dice/sides must be between 1 and 20.')
-        : message.reply('Rolling ' + dice + '... ' + '\n' + result);
+        ? message.reply('Number of dice/sides must be between 1 and 100.')
+        : message.reply('Rolling ' + dice + ' ... ' + '\n' + result);
     }
 
     if (userMsg.includes('tarot please')) {

--- a/src/dnd/dice/DiceRoller.js
+++ b/src/dnd/dice/DiceRoller.js
@@ -3,8 +3,8 @@ exports.rollDice = (diceString) => {
   var [numDice, numSides] = diceString.split('d').map(Number);
   var resultString = '';
   // Validation: Ensure numSides is between 1 and 20
-  if (numSides < 1 || numSides > 20 || numDice < 1 || numDice > 20) {
-    console.log('Number of dice/sides must be between 1 and 20.');
+  if (numSides < 1 || numSides > 100 || numDice < 1 || numDice > 100) {
+    console.log('Number of sides must be between 1 and 100.');
     return resultString;
   }
 

--- a/src/dnd/dice/DiceRoller.js
+++ b/src/dnd/dice/DiceRoller.js
@@ -24,7 +24,7 @@ exports.rollDice = (diceString) => {
   if (numDice === 1) {
     resultString = `Result: ${total}`;
   } else {
-    resultString = `Result: ${results.join(' + ')} = ${total}`;
+    resultString = `Result: ( ${results.join(' + ')} ) = ${total}`;
   }
 
   return resultString;

--- a/src/dnd/tarot/TarotCard.js
+++ b/src/dnd/tarot/TarotCard.js
@@ -1,0 +1,35 @@
+const fs = require('fs');
+
+// Define a TarotCard class
+class TarotCard {
+  constructor(name, alternateName, core, subtric, type, shortDescription, longDescription) {
+    this.name = name;
+    this.alternateName = alternateName;
+    this.core = core;
+    this.subtric = subtric;
+    this.type = type;
+    this.shortDescription = shortDescription;
+    this.longDescription = longDescription;
+  }
+}
+
+// Read JSON data from file
+exports.readJsonFromFile = (filePath) => {
+  try {
+    const data = fs.readFileSync(filePath, 'utf8');
+    const jsonData = JSON.parse(data);
+    return mapJsonToTarotCards(jsonData);
+  } catch (error) {
+    console.error('Error reading JSON file:', error);
+    return null;
+  }
+};
+
+// Function to map JSON data to TarotCard objects
+function mapJsonToTarotCards(jsonData) {
+  return jsonData.map((cardData) => {
+    const { name, alternateName, core, subtric, type, description } = cardData;
+    const { short, long } = description;
+    return new TarotCard(name, alternateName, core, subtric, type, short, long);
+  });
+}

--- a/src/dnd/tarot/TarotReader.js
+++ b/src/dnd/tarot/TarotReader.js
@@ -9,9 +9,10 @@ const filePath = path.join(__dirname, 'tarot_cards.json');
 exports.tarotReading = () => {
   const tarotCards = readJsonFromFile(filePath);
   const twoCards = shuffleArrayAndDrawTwo(tarotCards);
-  var response = '';
+  var response =
+    'Think of something at the forefront of your mind. Something that occupies you. I will draw two cards. The first will tell you what is already inside you, what exists in the present. The second reveals what you must find. This represents your future. \nNow reveal your cards.\n\n';
   twoCards.forEach((tarotCard) => {
-    response += `${tarotCard.name},\n${tarotCard.shortDescription}\n\n`;
+    response += `||**${tarotCard.name}**\n${tarotCard.shortDescription} ${tarotCard.longDescription}||\n\n`;
   });
   return response;
 };

--- a/src/dnd/tarot/TarotReader.js
+++ b/src/dnd/tarot/TarotReader.js
@@ -1,0 +1,26 @@
+//This class is for performing a tarot reading.
+const { readJsonFromFile } = require('./TarotCard');
+const path = require('path');
+
+// Get the absolute path to the JSON file
+const filePath = path.join(__dirname, 'tarot_cards.json');
+//content sourced from 'Elements of the source'.
+
+exports.tarotReading = () => {
+  const tarotCards = readJsonFromFile(filePath);
+  const twoCards = shuffleArrayAndDrawTwo(tarotCards);
+  var response = '';
+  twoCards.forEach((tarotCard) => {
+    response += `${tarotCard.name},\n${tarotCard.shortDescription}\n\n`;
+  });
+  return response;
+};
+
+// Function to shuffle an array in place using Fisher-Yates algorithm
+function shuffleArrayAndDrawTwo(array) {
+  for (let i = array.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [array[i], array[j]] = [array[j], array[i]];
+  }
+  return array.slice(0, 2);
+}

--- a/src/dnd/tarot/tarot_cards.json
+++ b/src/dnd/tarot/tarot_cards.json
@@ -163,5 +163,225 @@
       "short": "It is the fall that injures you.",
       "long": "Everything declines. You walk through the heart of Ruin on all sides. All feels lost to Corruption. But walk on. There is a rebuilding after the collapse."
     }
+  },
+  {
+    "name": "Strength",
+    "alternateName": "none",
+    "core": "Power",
+    "subtric": "Control",
+    "type": "minor",
+    "description": {
+      "short": "Shape and direct your surroundings.",
+      "long": "You use Strength to impose a new plan. You exert Control through intuition and the means at your disposal. The strong make themselves potential targets, include others int he process."
+    }
+  },
+  {
+    "name": "Intention",
+    "alternateName": "none",
+    "core": "Power",
+    "subtric": "Control",
+    "type": "minor",
+    "description": {
+      "short": "What do you want, and why?",
+      "long": "What will you do with the Control you wield? To what end are you working towards? What is the Intention of your actions? Without direction we cannot help but be misunderstood."
+    }
+  },
+  {
+    "name": "Form",
+    "alternateName": "none",
+    "core": "Power",
+    "subtric": "Chaos",
+    "type": "minor",
+    "description": {
+      "short": "Execute the plans you have made",
+      "long": "Within the storm of Chaos, a Form awaits to be discovered. You create the universe into being by freeing the figure of it from the block of stone. It is time to move on the plans you've been making."
+    }
+  },
+  {
+    "name": "Fracture",
+    "alternateName": "none",
+    "core": "Power",
+    "subtric": "Chaos",
+    "type": "minor",
+    "description": {
+      "short": "What you have can break apart.",
+      "long": "The center does not hold. You have given in to Chaos. Your plans begin to Fracture and drift. You are aimless. Fill your broken edges with gold and bear the pieces away."
+    }
+  },
+  {
+    "name": "Solidarity",
+    "alternateName": "none",
+    "core": "Unity",
+    "subtric": "Harmony",
+    "type": "minor",
+    "description": {
+      "short": "Strength within the collective.",
+      "long": "It often takes Solidarity within a group to achieve a goal. Allow yourself to find this Harmony with others so that you may attain your true purpose."
+    }
+  },
+  {
+    "name": "Solitude",
+    "alternateName": "none",
+    "core": "Unity",
+    "subtric": "Harmony",
+    "type": "minor",
+    "description": {
+      "short": "Personal truth may set others free.",
+      "long": "Being in Solitude can open the eyes. It can cause you to see the world of others in a new light. Find Harmony within yourself. Bring that truth back to the collective."
+    }
+  },
+  {
+    "name": "Disorder",
+    "alternateName": "none",
+    "core": "Unity",
+    "subtric": "Dissonance",
+    "type": "minor",
+    "description": {
+      "short": "It is time to push against order.",
+      "long": "Ignore the rules. Being a force of Disorder causes the universe to realign, to take the Dissonance, and make harmony with you. Kick against those that would quiet you."
+    }
+  },
+  {
+    "name": "Symmetry",
+    "alternateName": "none",
+    "core": "Unity",
+    "subtric": "Dissonance",
+    "type": "minor",
+    "description": {
+      "short": "There is always a third way.",
+      "long": "A coin spins in perfect Symmetry. What side it lands on is less important than making the guess. The Dissonance of taking a leap without seeing the landing is where the answer lies."
+    }
+  },
+  {
+    "name": "Inertia",
+    "alternateName": "none",
+    "core": "Transition",
+    "subtric": "Motion",
+    "type": "minor",
+    "description": {
+      "short": "Speed is exhilarating and tiring.",
+      "long": "When Motion becomes the norm, Inertia creeps in. Be careful to not overshoot your goal post or leave too many waves in your wake. It is easy to forget to slow down."
+    }
+  },
+  {
+    "name": "Momentum",
+    "alternateName": "none",
+    "core": "Transition",
+    "subtric": "Motion",
+    "type": "minor",
+    "description": {
+      "short": "Your choices are pushing you forward.",
+      "long": "You've exploded prospects and shot forward with Motion. There is no stopping your growing Momentum. At these speeds, it becomes easy to ignore others and their needs."
+    }
+  },
+  {
+    "name": "Direction",
+    "alternateName": "none",
+    "core": "Transition",
+    "subtric": "Stagnation",
+    "type": "minor",
+    "description": {
+      "short": "The time for debate is over.",
+      "long": "Avoid Stagnation. Point yourself in a singular Direction and go forth. This is your northstar. Singular thought may drive your process, but allow for deviations as needed."
+    }
+  },
+  {
+    "name": "Moor",
+    "alternateName": "none",
+    "core": "Transition",
+    "subtric": "Stagnation",
+    "type": "minor",
+    "description": {
+      "short": "Lack of motivation will stick you in place.",
+      "long": "Expectations Moor you in place. The weight of everything has buried you. Look around. This is an illusion of Stagnation. You can create multitudes with what you have."
+    }
+  },
+  {
+    "name": "Innocence",
+    "alternateName": "none",
+    "core": "Mystery",
+    "subtric": "Wonder",
+    "type": "minor",
+    "description": {
+      "short": "Weakness can be strength.",
+      "long": "Your Wonder pierces veils, brings insight, shatters propriety and conformity. Do not let anyone mistake your Innocence for weakness. Be a child. See with new eyes."
+    }
+  },
+  {
+    "name": "Inevitability",
+    "alternateName": "none",
+    "core": "Mystery",
+    "subtric": "Wonder",
+    "type": "minor",
+    "description": {
+      "short": "The ending isn't told yet.",
+      "long": "Wonder often gives way to weariness and inevitibility. Things feel like stops along a predetermined route. Get off at the right stop. Find a new ride. But do not be naive about the time you have."
+    }
+  },
+  {
+    "name": "Potential",
+    "alternateName": "none",
+    "core": "Mystery",
+    "subtric": "Expectation",
+    "type": "minor",
+    "description": {
+      "short": "Everything is within your grasp.",
+      "long": "Your Potential spreads out to seize the strings of fate. There is pressure to meet Expectation but the future is not locked in place. You have endless dreams, do not lose sight of them."
+    }
+  },
+  {
+    "name": "Perspective",
+    "alternateName": "none",
+    "core": "Mystery",
+    "subtric": "Expectation.",
+    "type": "minor",
+    "description": {
+      "short": "Look at things through a different door.",
+      "long": "The Expectation of choosing the right path has clouded your judement. You are holding up the line. Find Perspective. Doors go both ways. You have keys to them all."
+    }
+  },
+  {
+    "name": "Abstraction",
+    "alternateName": "none",
+    "core": "Creation",
+    "subtric": "Shape",
+    "type": "minor",
+    "description": {
+      "short": "The present causes what is next.",
+      "long": "The future often takes Shape from the present. You can see a lifetime of new possibilities waiting to be born within the Abstraction. Make Plans to see the vision realized."
+    }
+  },
+  {
+    "name": "Realization",
+    "alternateName": "none",
+    "core": "Creation",
+    "subtric": "Shape",
+    "type": "minor",
+    "description": {
+      "short": "What you see is the truth.",
+      "long": "The formless given Shape. You have a Realization of truth, division, everything once unclear. Be sure it is your truth and not a reflection of what you hope to see."
+    }
+  },
+  {
+    "name": "Obstruction",
+    "alternateName": "none",
+    "core": "Creation",
+    "subtric": "Shadow",
+    "type": "minor",
+    "description": {
+      "short": "Roadblocks must be taken down.",
+      "long": "The road turns to Obstruction. Light turns to Shadow. Look at your choices. You made this road. It is time to leap over the roadblocks made for yourself. Reimagine the path forward."
+    }
+  },
+  {
+    "name": "Projection",
+    "alternateName": "none",
+    "core": "Creation",
+    "subtric": "Shadow",
+    "type": "minor",
+    "description": {
+      "short": "Illusions are enticing but not true.",
+      "long": "Light dances. Shadow answers. But dark gives context to light. You see from many angles; plan for what you see and don't fall for illusions created by subconscious Projection."
+    }
   }
 ]

--- a/src/dnd/tarot/tarot_cards.json
+++ b/src/dnd/tarot/tarot_cards.json
@@ -1,0 +1,167 @@
+[
+  {
+    "name": "desire",
+    "alternateName": "The hand that reaches",
+    "core": "core",
+    "subtric": "none",
+    "type": "major",
+    "description": {
+      "short": "Yearning limits or upraises",
+      "long": "Absence and Abundance. Do not focus on what you do not have. Let desire motivate, not weigh you down with the unneeded ephemera of this world. Desire is movement. be bold."
+    }
+  },
+  {
+    "name": "Transition",
+    "alternateName": "The hand that turns",
+    "core": "core",
+    "subtric": "none",
+    "type": "major",
+    "description": {
+      "short": "Evolve with the shifting road",
+      "long": "Motion and Stagnation. Embrace Transition or risk falling behind the ever turning cycle of day and night. Resist and the wheel may crack sending you out of the order of things and deep into despair. Lean into the corners of the road."
+    }
+  },
+  {
+    "name": "Unity",
+    "alternateName": "The hand that bonds",
+    "core": "core",
+    "subtric": "none",
+    "type": "major",
+    "description": {
+      "short": "Finding self within or without",
+      "long": "Harmony and Dissonance. Being a part of a group can transform the singular. Unity can elevate or consume. Explore the messiness of convergence. Sing in unison but find your own notes."
+    }
+  },
+  {
+    "name": "Mystery",
+    "alternateName": "The hand that masks",
+    "core": "core",
+    "subtric": "none",
+    "type": "major",
+    "description": {
+      "short": "Making your own answers",
+      "long": "Wonder and Expectation. Pieces of the puzzles you seek to solve wait for discovery. Strike out on your own to unmask the truths beyond. Gather the pieces and discover. Embrace the challenge."
+    }
+  },
+  {
+    "name": "Creation",
+    "alternateName": "The hand that forges",
+    "core": "core",
+    "subtric": "none",
+    "type": "major",
+    "description": {
+      "short": "Becoming a conduit for growth.",
+      "long": "Shape and Shadow. New ideas and new forces are given form. Your potential is at its peak, do not let yourself be stifled by fear of failure or of being an imposter. Embrace the universal and help the multitudes grow through your acts."
+    }
+  },
+  {
+    "name": "Power",
+    "alternateName": "The hand that gives",
+    "core": "core",
+    "subtric": "none",
+    "type": "major",
+    "description": {
+      "short": "Manifesting will for good or ill.",
+      "long": "Control and Chaos. The very substance of change. Use but do not make demands of power, it can also move what is wanted further from you. The best laid plans can always turn to dust."
+    }
+  },
+  {
+    "name": "Purity",
+    "alternateName": "The hand that cuts",
+    "core": "core",
+    "subtric": "none",
+    "type": "major",
+    "description": {
+      "short": "Responsibility rests within yourself.",
+      "long": "Cure and Corruption. A personal set of scales that no one but you can tip in any one direction. Purity is not a binary. Remove the masks others have placed on you."
+    }
+  },
+  {
+    "name": "Oblivion",
+    "alternateName": "none",
+    "core": "Desire",
+    "subtric": "Absence",
+    "type": "minor",
+    "description": {
+      "short": "Nothingness is erasure and creation.",
+      "long": "Absence is a void one might wish to escape. Looking within can freeze one with fear. However, within Oblivion, there could be a path undiscovered. You are your own key."
+    }
+  },
+  {
+    "name": "Longing",
+    "alternateName": "none",
+    "core": "Desire",
+    "subtric": "Absence",
+    "type": "minor",
+    "description": {
+      "short": "Equilibrium between want and need.",
+      "long": "An awareness of Absence leads one to seek. But Longing can drive one to misery if searching the horizen leads one to ignore the foreground. Find equilibrium."
+    }
+  },
+  {
+    "name": "Burden",
+    "alternateName": "none",
+    "core": "Desire",
+    "subtric": "Abundance",
+    "type": "minor",
+    "description": {
+      "short": "The more you carry, the slower you move.",
+      "long": "How much can one hold? What good is security if it does not bring bliss? Abundance is also a Burden. A horde of riches to drown in. Lay down your excess. Simplify. Give."
+    }
+  },
+  {
+    "name": "Prosperity",
+    "alternateName": "none",
+    "core": "Desire",
+    "subtric": "Abundance",
+    "type": "minor",
+    "description": {
+      "short": "What is full today may empty tomorrow.",
+      "long": "Your table is full. You have achieved so much but must decide what to do with this Abundance. Prosperity is wonderful, but can be lost in an instant. Be smart with your wealth."
+    }
+  },
+  {
+    "name": "Nuture",
+    "alternateName": "none",
+    "core": "Purity",
+    "subtric": "Cure",
+    "type": "minor",
+    "description": {
+      "short": "Plant the seeds to sow tomorrow.",
+      "long": "A hand outstretched and a Cure offered in return. Alleviate suffering, allow another to thrive. Give a piece of yourself, but also Nurture a practice of protection of self."
+    }
+  },
+  {
+    "name": "Need",
+    "alternateName": "none",
+    "core": "Purity",
+    "subtric": "Cure",
+    "type": "minor",
+    "description": {
+      "short": "Acknowledge the lack within you.",
+      "long": "Need burns inside you, a star unborn. Marshal all your resources and search onwards for the Cure to this current suffering, but beware of becoming trapped by the pain."
+    }
+  },
+  {
+    "name": "Rise",
+    "alternateName": "none",
+    "core": "Purity",
+    "subtric": "Corruption",
+    "type": "minor",
+    "description": {
+      "short": "Greatness is possible.",
+      "long": "The journey can be the destination. A Rise can also be a fall, if one gives in to Corruption of the self. Trust the climb. Do not lose sight of yourself."
+    }
+  },
+  {
+    "name": "Ruin",
+    "alternateName": "none",
+    "core": "Purity",
+    "subtric": "Corruption",
+    "type": "minor",
+    "description": {
+      "short": "It is the fall that injures you.",
+      "long": "Everything declines. You walk through the heart of Ruin on all sides. All feels lost to Corruption. But walk on. There is a rebuilding after the collapse."
+    }
+  }
+]


### PR DESCRIPTION
This PR adds the ability to perform tarot readings. There is a preset deck of tarot cards loaded from a json file. 
To perform a tarot reading, the user just has to type tarot please. 

Changes:
- added tarot readings
- added a json of a full tarot card deck (sourced from Elements of the Source)
- allowed d100 dice in the dice roller. 
- added a help menu